### PR TITLE
Cast of two variables to avoid warnings

### DIFF
--- a/RMPhoneFormat/RMPhoneFormat.m
+++ b/RMPhoneFormat/RMPhoneFormat.m
@@ -618,7 +618,7 @@ static NSMutableDictionary *flagRules = nil;
 
 + (NSString *)strip:(NSString *)str {
     NSMutableString *res = [NSMutableString stringWithString:str];
-    for (int i = [res length] - 1; i >= 0; i--) {
+    for (int i = (int)[res length] - 1; i >= 0; i--) {
         if (![phoneChars characterIsMember:[res characterAtIndex:i]]) {
             [res deleteCharactersInRange:NSMakeRange(i, 1)];
         }
@@ -861,7 +861,7 @@ static NSMutableDictionary *flagRules = nil;
         NSNumber *num = [_callingCodeOffsets objectForKey:callingCode];
         if (num) {
             const uint8_t *bytes = [_data bytes];
-            uint32_t start = [num longValue];
+            uint32_t start = (uint32_t)[num longValue];
             uint32_t offset = start;
             res = [[CallingCodeInfo alloc] init];
             res.callingCode = callingCode;


### PR DESCRIPTION
On xcode 7, those two lines will generate warnings of size trimming (which in this case is not an issue).

Forced cast inserted to remove the warnings.
